### PR TITLE
Tolerate having an IRolesPlugin.getRolesForPrincipal return None.

### DIFF
--- a/plone/app/controlpanel/usergroups.py
+++ b/plone/app/controlpanel/usergroups.py
@@ -218,7 +218,9 @@ class UsersOverviewControlPanel(UsersGroupsControlPanelView):
                 continue
             allAssignedRoles = []
             for rolemaker_id, rolemaker in rolemakers:
-                allAssignedRoles.extend(rolemaker.getRolesForPrincipal(user))
+                # getRolesForPrincipal can return None
+                roles = rolemaker.getRolesForPrincipal(user) or ()
+                allAssignedRoles.extend(roles)
             allInheritedRoles[userId] = allAssignedRoles
 
         # We push this in the request such IRoles plugins don't provide
@@ -239,7 +241,9 @@ class UsersOverviewControlPanel(UsersGroupsControlPanelView):
                 continue
             explicitlyAssignedRoles = []
             for rolemaker_id, rolemaker in rolemakers:
-                explicitlyAssignedRoles.extend(rolemaker.getRolesForPrincipal(user))
+                # getRolesForPrincipal can return None
+                roles = rolemaker.getRolesForPrincipal(user) or ()
+                explicitlyAssignedRoles.extend(roles)
 
             roleList = {}
             for role in self.portal_roles:
@@ -491,7 +495,9 @@ class GroupsOverviewControlPanel(UsersGroupsControlPanelView):
             group_info['title'] = group.getProperty('title', group_info['title'])
             allAssignedRoles = []
             for rolemaker_id, rolemaker in rolemakers:
-                allAssignedRoles.extend(rolemaker.getRolesForPrincipal(group))
+                # getRolesForPrincipal can return None
+                roles = rolemaker.getRolesForPrincipal(group) or ()
+                allAssignedRoles.extend(rolemaker.getRolesForPrincipal(roles))
             allInheritedRoles[groupId] = allAssignedRoles
 
         # Now, search for all roles explicitly assigned to each group.
@@ -511,7 +517,9 @@ class GroupsOverviewControlPanel(UsersGroupsControlPanelView):
 
             explicitlyAssignedRoles = []
             for rolemaker_id, rolemaker in rolemakers:
-                explicitlyAssignedRoles.extend(rolemaker.getRolesForPrincipal(group))
+                # getRolesForPrincipal can return None
+                roles = rolemaker.getRolesForPrincipal(group) or ()
+                explicitlyAssignedRoles.extend(roles)
 
             roleList = {}
             for role in self.portal_roles:


### PR DESCRIPTION
The local role plugin in particular can return None:  the UI should not break
when it does.
