### PR TITLE
add text-decoration to allowed css style attributes @@filter-controlpanel

### DIFF
--- a/plone/app/controlpanel/filter.py
+++ b/plone/app/controlpanel/filter.py
@@ -85,7 +85,7 @@ class IFilterEditorSchema(Interface):
     style_whitelist = schema.List(
         title=_(u'Permitted properties'),
         description=_(u'These CSS properties are allowed in style attributes.'),
-        default=u'text-align list-style-type float'.split(),
+        default=u'text-align list-style-type float text-decoration'.split(),
         value_type=schema.TextLine(),
         required=False)
 


### PR DESCRIPTION
By default, TinyMCE allows strike-through editing (next to bold and italic). This done with "text-decoration: line-through;". However, as soon as you save the edit, this is lost due to the very restricted html filters of plone. filters should be in sync with TinyMCE
