### PR TITLE
Remove usage of popupforms.js

### DIFF
--- a/plone/app/controlpanel/skins.py
+++ b/plone/app/controlpanel/skins.py
@@ -55,12 +55,6 @@ class ISkinsSchema(Interface):
                                             "won't be visible."),
                              vocabulary=ICON_VISIBILITY_VOCABULARY)
 
-    use_popups = Bool(title=_(u'Use popup overlays for simple forms'),
-                        description=_(u"If enabled popup overlays will be "
-                                       "used for simple forms like login, "
-                                       "contact and delete confirmation."),
-                        default=True)
-
 
 class SkinsControlPanelAdapter(SchemaAdapterBase):
 
@@ -139,26 +133,6 @@ class SkinsControlPanelAdapter(SchemaAdapterBase):
         self.props.manage_changeProperties(icon_visibility=value)
 
     icon_visibility = property(get_icon_visibility,set_icon_visibility)
-
-    def get_use_popups(self):
-        popupforms = self.jstool.getResource('popupforms.js')
-        if popupforms:
-            return popupforms.getEnabled()
-        jqoverlays = self.csstool.getResource('++resource++plone.app.jquerytools.overlays.css')
-        if jqoverlays:
-            return jqoverlays.getEnabled()
-
-    def set_use_popups(self, value):
-        popupforms = self.jstool.getResource('popupforms.js')
-        if popupforms:
-            popupforms.setEnabled(value)
-        self.jstool.cookResources()
-        jqoverlays = self.csstool.getResource('++resource++plone.app.jquerytools.overlays.css')
-        if jqoverlays:
-            jqoverlays.setEnabled(value)
-        self.csstool.cookResources()
-
-    use_popups = property(get_use_popups, set_use_popups)
 
 
 class SkinsControlPanel(ControlPanelForm):

--- a/plone/app/controlpanel/tests/skins.txt
+++ b/plone/app/controlpanel/tests/skins.txt
@@ -130,27 +130,3 @@ Unchecking new_window should finally turn off the js support:
 
     >>> jstool.getResource('mark_special_links.js').getEnabled()
     False
-
-
-Overlayed popup forms are also controlled here
--------------------------------------------------------------------
-
-We should be starting with popupforms.js enabled:
-
-    >>> jstool = getToolByName(self.portal, 'portal_javascripts')
-    >>> jstool.getResource('popupforms.js').getEnabled()
-    True
-
-Unchecking use_popups should turn off the js support:
-
-    >>> self.browser.getControl(name='form.use_popups').value = False
-    >>> self.browser.getControl(name="form.actions.save").click()
-    >>> jstool.getResource('popupforms.js').getEnabled()
-    False
-
-Checking use_popups should turn re-enable:
-
-    >>> self.browser.getControl(name='form.use_popups').value = True
-    >>> self.browser.getControl(name="form.actions.save").click()
-    >>> jstool.getResource('popupforms.js').getEnabled()
-    True


### PR DESCRIPTION
See https://github.com/plone/Products.CMFPlone/issues/282

The popupforms.js code is deprecated and no longer needed due to mockup (and specifically pat-modal).

The code removed here added a controlpanel skins' setting for enabling popupforms.

ping @vangheem  @thet 
