### PR TITLE
Fix tests for syndication control panel to pass also with new plone.app.registry version

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,8 +4,9 @@ Changelog
 2.3.10 (unreleased)
 -------------------
 
-- Nothing changed yet.
-
+- Fix tests for syndication control panel to pass also with
+  new plone.app.registry versions
+  [Asko Soukka]
 
 2.3.9 (2015-09-27)
 ------------------

--- a/plone/app/controlpanel/tests/syndication.txt
+++ b/plone/app/controlpanel/tests/syndication.txt
@@ -19,7 +19,8 @@ Edit some settings and make sure they stick.
 
 We should be back on the Site Setup screen:
 
-    >>> 'plone_control_panel' in self.browser.url
+    >>> ('plone_control_panel' in self.browser.url or
+    ...  '@@overview-controlpanel' in self.browser.url)
     True
 
 Navigate back to the syndication settings:


### PR DESCRIPTION
Required to make tests pass for https://github.com/plone/plone.app.registry/pull/23 on Plone 4.3